### PR TITLE
Require SQL comment hint to Doctrine types

### DIFF
--- a/src/Doctrine/DurationType.php
+++ b/src/Doctrine/DurationType.php
@@ -37,4 +37,9 @@ final class DurationType extends Type
     {
         return 'duration';
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
 }

--- a/src/Doctrine/InstantType.php
+++ b/src/Doctrine/InstantType.php
@@ -48,4 +48,9 @@ final class InstantType extends Type
     {
         return 'instant';
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
 }

--- a/src/Doctrine/LocalDateTimeType.php
+++ b/src/Doctrine/LocalDateTimeType.php
@@ -36,4 +36,9 @@ final class LocalDateTimeType extends Type
     {
         return 'local_datetime';
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
 }

--- a/src/Doctrine/LocalDateType.php
+++ b/src/Doctrine/LocalDateType.php
@@ -28,4 +28,9 @@ final class LocalDateType extends Type
     {
         return 'local_date';
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
 }

--- a/src/Doctrine/LocalTimeType.php
+++ b/src/Doctrine/LocalTimeType.php
@@ -28,4 +28,9 @@ final class LocalTimeType extends Type
     {
         return 'local_time';
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
 }

--- a/src/Doctrine/TimeZoneOffsetType.php
+++ b/src/Doctrine/TimeZoneOffsetType.php
@@ -31,4 +31,9 @@ final class TimeZoneOffsetType extends Type
     {
         return 'timezone_offset_type';
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
 }

--- a/src/Doctrine/TimeZoneType.php
+++ b/src/Doctrine/TimeZoneType.php
@@ -40,4 +40,9 @@ final class TimeZoneType extends Type
     {
         return 'timezone';
     }
+
+    public function requiresSQLCommentHint(AbstractPlatform $platform): bool
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
Allows to automatically add the SQL comment `'(DC2Type:..)'` after a migration generation.

```
ALTER TABLE my_table
    ADD range_start DATE DEFAULT NULL COMMENT '(DC2Type:local_date)',
    ADD range_end DATE DEFAULT NULL COMMENT '(DC2Type:local_date)'
```