### PR TITLE
Keep the previous exception when rethrowing parse errors

### DIFF
--- a/src/Normalizer/DurationNormalizer.php
+++ b/src/Normalizer/DurationNormalizer.php
@@ -30,7 +30,7 @@ final class DurationNormalizer implements NormalizerInterface, DenormalizerInter
         try {
             return Duration::parse($data);
         } catch (DateTimeException $e) {
-            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type));
+            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type), 0, $e);
         }
     }
 

--- a/src/Normalizer/InstantNormalizer.php
+++ b/src/Normalizer/InstantNormalizer.php
@@ -31,7 +31,7 @@ final class InstantNormalizer implements NormalizerInterface, DenormalizerInterf
         try {
             return ZonedDateTime::parse($data)->getInstant();
         } catch (DateTimeException $e) {
-            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type));
+            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type), 0, $e);
         }
     }
 

--- a/src/Normalizer/LocalDateIntervalNormalizer.php
+++ b/src/Normalizer/LocalDateIntervalNormalizer.php
@@ -30,7 +30,7 @@ final class LocalDateIntervalNormalizer implements NormalizerInterface, Denormal
         try {
             return LocalDateInterval::parse($data);
         } catch (DateTimeException $e) {
-            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type));
+            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type), 0, $e);
         }
     }
 

--- a/src/Normalizer/LocalDateNormalizer.php
+++ b/src/Normalizer/LocalDateNormalizer.php
@@ -30,7 +30,7 @@ final class LocalDateNormalizer implements NormalizerInterface, DenormalizerInte
         try {
             return LocalDate::parse($data);
         } catch (DateTimeException $e) {
-            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type));
+            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type), 0, $e);
         }
     }
 

--- a/src/Normalizer/LocalDateTimeIntervalNormalizer.php
+++ b/src/Normalizer/LocalDateTimeIntervalNormalizer.php
@@ -30,7 +30,7 @@ final class LocalDateTimeIntervalNormalizer implements NormalizerInterface, Deno
         try {
             return LocalDateTimeInterval::parse($data);
         } catch (DateTimeException $e) {
-            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type));
+            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type), 0, $e);
         }
     }
 

--- a/src/Normalizer/LocalDateTimeNormalizer.php
+++ b/src/Normalizer/LocalDateTimeNormalizer.php
@@ -30,7 +30,7 @@ final class LocalDateTimeNormalizer implements NormalizerInterface, Denormalizer
         try {
             return LocalDateTime::parse($data);
         } catch (DateTimeException $e) {
-            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type));
+            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type), 0, $e);
         }
     }
 

--- a/src/Normalizer/LocalTimeIntervalNormalizer.php
+++ b/src/Normalizer/LocalTimeIntervalNormalizer.php
@@ -30,7 +30,7 @@ final class LocalTimeIntervalNormalizer implements NormalizerInterface, Denormal
         try {
             return LocalTimeInterval::parse($data);
         } catch (Throwable $e) {
-            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type));
+            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type), 0, $e);
         }
     }
 

--- a/src/Normalizer/LocalTimeNormalizer.php
+++ b/src/Normalizer/LocalTimeNormalizer.php
@@ -30,7 +30,7 @@ final class LocalTimeNormalizer implements NormalizerInterface, DenormalizerInte
         try {
             return LocalTime::parse($data);
         } catch (DateTimeException $e) {
-            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type));
+            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type), 0, $e);
         }
     }
 

--- a/src/Normalizer/MonthDayNormalizer.php
+++ b/src/Normalizer/MonthDayNormalizer.php
@@ -30,7 +30,7 @@ final class MonthDayNormalizer implements NormalizerInterface, DenormalizerInter
         try {
             return MonthDay::parse($data);
         } catch (DateTimeException $e) {
-            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type));
+            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type), 0, $e);
         }
     }
 

--- a/src/Normalizer/YearMonthNormalizer.php
+++ b/src/Normalizer/YearMonthNormalizer.php
@@ -30,7 +30,7 @@ final class YearMonthNormalizer implements NormalizerInterface, DenormalizerInte
         try {
             return YearMonth::parse($data);
         } catch (DateTimeException $e) {
-            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type));
+            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type), 0, $e);
         }
     }
 

--- a/src/Normalizer/YearNormalizer.php
+++ b/src/Normalizer/YearNormalizer.php
@@ -30,7 +30,7 @@ final class YearNormalizer implements NormalizerInterface, DenormalizerInterface
         try {
             return Year::of((int) $data);
         } catch (DateTimeException $e) {
-            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type));
+            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type), 0, $e);
         }
     }
 

--- a/src/Normalizer/YearWeekNormalizer.php
+++ b/src/Normalizer/YearWeekNormalizer.php
@@ -32,9 +32,9 @@ final class YearWeekNormalizer implements NormalizerInterface, DenormalizerInter
         try {
             return YearWeek::of(...map((array) explode('-W', (string) $data, 2), static fn (string $part): int => (int) $part));
         } catch (DateTimeException $e) {
-            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type));
-        } catch (Throwable) {
-            throw new NotNormalizableValueException('Invalid format for year week.');
+            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type), 0, $e);
+        } catch (Throwable $e) {
+            throw new NotNormalizableValueException('Invalid format for year week.', 0, $e);
         }
     }
 

--- a/src/Normalizer/ZonedDateTimeNormalizer.php
+++ b/src/Normalizer/ZonedDateTimeNormalizer.php
@@ -30,7 +30,7 @@ final class ZonedDateTimeNormalizer implements NormalizerInterface, Denormalizer
         try {
             return ZonedDateTime::parse($data);
         } catch (DateTimeException $e) {
-            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type));
+            throw new NotNormalizableValueException(sprintf('%s (%s)', $e->getMessage(), $type), 0, $e);
         }
     }
 


### PR DESCRIPTION
```php
public Exception::__construct(string $message = "", int $code = 0, ?Throwable $previous = null)
```

> previous: The previous exception used for the exception chaining.