### PR TITLE
Throws its own exceptions

### DIFF
--- a/src/Exceptions/Assert/Assert.php
+++ b/src/Exceptions/Assert/Assert.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gammadia\DateTimeExtra\Exceptions\Assert;
+
+use Gammadia\DateTimeExtra\Exceptions\InvalidArgumentException;
+
+class Assert extends \Webmozart\Assert\Assert
+{
+    protected static function reportInvalidArgument($message)
+    {
+        throw new InvalidArgumentException($message);
+    }
+}

--- a/src/Exceptions/ExceptionInterface.php
+++ b/src/Exceptions/ExceptionInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gammadia\DateTimeExtra\Exceptions;
+
+interface ExceptionInterface extends \Throwable
+{
+}

--- a/src/Exceptions/IntervalParseException.php
+++ b/src/Exceptions/IntervalParseException.php
@@ -7,7 +7,7 @@ namespace Gammadia\DateTimeExtra\Exceptions;
 use RuntimeException;
 use Throwable;
 
-final class IntervalParseException extends RuntimeException
+final class IntervalParseException extends RuntimeException implements ExceptionInterface
 {
     public static function uniqueDuration(string $textToParse): self
     {

--- a/src/Exceptions/InvalidArgumentException.php
+++ b/src/Exceptions/InvalidArgumentException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gammadia\DateTimeExtra\Exceptions;
+
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
+{
+
+}

--- a/src/LocalDateInterval.php
+++ b/src/LocalDateInterval.php
@@ -9,6 +9,7 @@ use Brick\DateTime\LocalTime;
 use Brick\DateTime\Period;
 use Brick\DateTime\YearWeek;
 use Doctrine\ORM\Mapping as ORM;
+use Gammadia\DateTimeExtra\Exceptions\Assert\Assert as DomainAssert;
 use Gammadia\DateTimeExtra\Exceptions\IntervalParseException;
 use JsonSerializable;
 use RuntimeException;
@@ -29,7 +30,7 @@ final class LocalDateInterval implements JsonSerializable, Stringable
         #[ORM\Column(type: 'local_date')]
         private ?LocalDate $end,
     ) {
-        Assert::false($start && $end && $start->isAfter($end), sprintf('Start after end: %s / %s', $start, $end));
+        DomainAssert::false($start && $end && $start->isAfter($end), sprintf('Start after end: %s / %s', $start, $end));
     }
 
     public function __toString(): string


### PR DESCRIPTION
I'm writting a validator based on exceptions thrown by `LocalDateInterval` but we need at the moment to catch Webmozart exceptions to handle domain errors.

```php
try {
    LocalDateInterval::parse($text);
} catch (\Gammadia\DateTimeExtra\Exceptions\IntervalParseException $e) {
    // handles parsing errors
} catch (\Webmozart\Assert\InvalidArgumentException $e) {
    // handles domain errors
}
```

This PR throws its own exceptions when it's domain specific and continues to call Webmozart namespaced exception when a error has to be handle in development process.

```php
catch (\Gammadia\DateTimeExtra\Exceptions\IntervalParseException $e) { // handles parsing errors }
catch (\Gammadia\DateTimeExtra\Exceptions\InvalidArgumentException $e) { // handles domain errors }
```

A base exception can also be caught for generic purpose :

```php
catch (\Gammadia\DateTimeExtra\Exceptions\ExceptionInterface $e) {}
```

